### PR TITLE
make gpr a shared library, add installation target and fix a few build errors on mac and linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ SET(GPR_HEADERS src/gcode_program.h
 SET(GPR_CPPS src/parser.cpp
 	     src/gcode_program.cpp)
 
-add_library(gpr ${GPR_CPPS})
+add_library(gpr SHARED ${GPR_CPPS})
 
 SET(TEST_FILES test/parser_tests.cpp
 	       test/main.cpp)
@@ -29,3 +29,5 @@ target_link_libraries(all-tests gpr)
 
 add_executable(parse-gcode src/main.cpp)
 target_link_libraries(parse-gcode gpr)
+
+install(TARGETS gpr LIBRARY DESTINATION lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ SET(GPR_HEADERS src/gcode_program.h
 SET(GPR_CPPS src/parser.cpp
 	     src/gcode_program.cpp)
 
+set(CMAKE_MACOSX_RPATH 1)
+
 add_library(gpr SHARED ${GPR_CPPS})
 
 SET(TEST_FILES test/parser_tests.cpp

--- a/src/gcode_program.h
+++ b/src/gcode_program.h
@@ -301,7 +301,7 @@ namespace gpr {
       line_no(other.line_no),
       slashed_out(other.slashed_out) {
 
-      for (unsigned i = 0; i < other.chunks.size(); i++) {
+      for (size_t i = 0; i < other.chunks.size(); i++) {
 	chunks.push_back( other.chunks[i] );
       }
 
@@ -311,7 +311,7 @@ namespace gpr {
       has_line_no = other.has_line_no;
       line_no = other.line_no;
       slashed_out = other.slashed_out;
-      for (unsigned i = 0; i < other.chunks.size(); i++) {
+      for (size_t i = 0; i < other.chunks.size(); i++) {
 	chunks.push_back( other.chunks[i] );
       }
 
@@ -381,7 +381,7 @@ namespace gpr {
 
     int num_blocks() const { return blocks.size(); }
 
-    block get_block(const int i) {
+    block get_block(const size_t i) {
       assert(i < blocks.size());
       return blocks[i];
     }

--- a/src/gcode_program.h
+++ b/src/gcode_program.h
@@ -134,6 +134,7 @@ namespace gpr {
     
   public:
     chunk() : chunk_tp(CHUNK_TYPE_PERCENT) {}
+    virtual ~chunk() {}
 
     chunk(const char c) : chunk_tp(CHUNK_TYPE_WORD), single_word(c) {}
 	      


### PR DESCRIPTION
make gpr a shared library, add installation target and fix a few build errors on mac and linux