### PR TITLE
Fix crash bug

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -282,7 +282,7 @@ namespace gpr {
   }
 
   std::pair<bool, int> parse_line_number(parse_stream<string>& s) {
-    if (s.next() == "N") {
+    if (s.chars_left() > 0 && s.next() == "N") {
       s++;
 
       int ln = parse_int(s);


### PR DESCRIPTION
I don't add any test because this crashed for me when I ran the already written unit tests.

The crash is in the HAAS unit test when it attempts to parse a line that contains "/"