### PR TITLE
Fix array out of bounds access bug

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -247,6 +247,9 @@ namespace gpr {
       string cs = parse_line_comment_with_delimiter(";", s);
       return chunk(';', ';', cs);
     } else {
+      if (s.i + 1 >= s.s.size()) {
+        return parse_isolated_word(s);
+      }
       string next_next = *(s.remaining() + 1);
 
       if (!is_num_char(next_next[0])) {

--- a/test/parser_tests.cpp
+++ b/test/parser_tests.cpp
@@ -151,6 +151,12 @@ namespace gpr {
     REQUIRE(p.get_block(0).get_chunk(4).tp() == CHUNK_TYPE_WORD);
   }
 
+  TEST_CASE("Parsing block only an isolated word 'P'") {
+    gcode_program p = parse_gcode("P");
+
+    REQUIRE(p.get_block(0).get_chunk(0).tp() == CHUNK_TYPE_WORD);
+  }
+
   TEST_CASE("Parse blank line") {
     gcode_program p =
       parse_gcode("G99 G82 R0.1 Z-0.1227 P F15.04\n   ");


### PR DESCRIPTION
This bug is triggered if a line ends with a command without a number.